### PR TITLE
fix(spren_flutter): support FlutterFragmentActivity by using Activity instead of FlutterActivity

### DIFF
--- a/flutter/android/src/main/java/com/spren/spren_flutter/CameraNativeView.java
+++ b/flutter/android/src/main/java/com/spren/spren_flutter/CameraNativeView.java
@@ -1,5 +1,5 @@
 package com.spren.spren_flutter;
-
+import android.app.Activity;
 import android.content.Context;
 import android.view.View;
 import androidx.annotation.NonNull;
@@ -12,7 +12,7 @@ import java.util.Map;
 public class CameraNativeView implements PlatformView {
     private SprenView sprenView;
 
-    CameraNativeView(@NonNull Context context, int id, @Nullable Map<String, Object> creationParams, BinaryMessenger binaryMessenger, FlutterActivity flutterActivity) {
+    CameraNativeView(@NonNull Context context, int id, @Nullable Map<String, Object> creationParams, BinaryMessenger binaryMessenger, Activity flutterActivity) {
         sprenView = new SprenView(context, binaryMessenger, flutterActivity);
     }
 

--- a/flutter/android/src/main/java/com/spren/spren_flutter/CameraNativeViewFactory.java
+++ b/flutter/android/src/main/java/com/spren/spren_flutter/CameraNativeViewFactory.java
@@ -1,5 +1,6 @@
 package com.spren.spren_flutter;
 
+import android.app.Activity;
 import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -11,14 +12,14 @@ import io.flutter.plugin.platform.PlatformView;
 import io.flutter.plugin.platform.PlatformViewFactory;
 
 public class CameraNativeViewFactory extends PlatformViewFactory {
-    FlutterActivity flutterActivity;
+    Activity flutterActivity;
     BinaryMessenger binaryMessenger;
 
     CameraNativeViewFactory() {
         super(StandardMessageCodec.INSTANCE);
     }
 
-    CameraNativeViewFactory(FlutterActivity flutterActivity, BinaryMessenger binaryMessenger) {
+    CameraNativeViewFactory(Activity flutterActivity, BinaryMessenger binaryMessenger) {
         this();
         this.flutterActivity = flutterActivity;
         this.binaryMessenger = binaryMessenger;

--- a/flutter/android/src/main/java/com/spren/spren_flutter/SprenFlutterPlugin.java
+++ b/flutter/android/src/main/java/com/spren/spren_flutter/SprenFlutterPlugin.java
@@ -1,5 +1,5 @@
 package com.spren.spren_flutter;
-
+import android.app.Activity;
 import androidx.annotation.NonNull;
 import com.spren.spren_flutter.stream.PreReadingComplianceCheckHandler;
 import com.spren.spren_flutter.stream.ProgressUpdateHandler;
@@ -30,7 +30,7 @@ public class SprenFlutterPlugin implements FlutterPlugin, ActivityAware {
 
     @Override
     public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
-        FlutterActivity flutterActivity = (FlutterActivity) binding.getActivity();
+        Activity flutterActivity = (Activity) binding.getActivity();
         CameraNativeViewFactory cameraNativeViewFactory = new CameraNativeViewFactory(flutterActivity, binaryMessenger);
         platformViewRegistry.registerViewFactory(SprenChannel.SPREN_CAMERA_VIEW.toString(), cameraNativeViewFactory);
     }

--- a/flutter/android/src/main/java/com/spren/spren_flutter/SprenView.java
+++ b/flutter/android/src/main/java/com/spren/spren_flutter/SprenView.java
@@ -1,5 +1,5 @@
 package com.spren.spren_flutter;
-
+import android.app.Activity;
 import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -27,7 +27,7 @@ import kotlin.Unit;
 import kotlin.jvm.functions.Function1;
 
 public class SprenView extends FrameLayout implements MethodChannel.MethodCallHandler {
-    private FlutterActivity flutterActivity;
+    private Activity flutterActivity;
     private SprenCapture sprenCapture;
     private Context context;
     private CoordinatorLayout container;
@@ -35,7 +35,7 @@ public class SprenView extends FrameLayout implements MethodChannel.MethodCallHa
     private MethodChannel methodChannel;
     private SprenViewCommands sprenViewCommands;
 
-    public SprenView(@NonNull Context context, BinaryMessenger binaryMessenger, FlutterActivity flutterActivity) {
+    public SprenView(@NonNull Context context, BinaryMessenger binaryMessenger, Activity flutterActivity) {
         super(context);
         this.context = context;
         this.flutterActivity = flutterActivity;


### PR DESCRIPTION
I needed to use `FlutterFragmentActivity` in my app but the plugin implementation assumed it's always `FlutterActivity`. By using just `Activity` it's possible to use both `FlutterFragmentActivity` and `FlutterActivity`