### PR TITLE
chore: make AGP 8 compatible by adding namespace declaration

### DIFF
--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 31
+    namespace 'com.spren.spren_flutter'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Seems like it's needed to support AGP8